### PR TITLE
Add playback rate controls to audio playback

### DIFF
--- a/lib/types/modules/AudioController.d.ts
+++ b/lib/types/modules/AudioController.d.ts
@@ -13,6 +13,7 @@ export default class WebAudioController extends WebAudio {
     private playing;
     private audioBufferSourceNode;
     private FADE_DURATION;
+    private playbackRate;
     constructor(props: IllestWaveformProps);
     get _playing(): boolean;
     get _currentTime(): number;
@@ -21,6 +22,7 @@ export default class WebAudioController extends WebAudio {
     pick(pickedTime: number): void;
     replay(): void;
     finish(): void;
+    setPlaybackRate(rate: number): void;
     private initializeState;
     private createAudioBufferSourceNode;
     private connectDestination;

--- a/src/components/IllestWaveform.vue
+++ b/src/components/IllestWaveform.vue
@@ -161,6 +161,10 @@ function finish(): void {
   emits('onFinish', true)
 }
 
+function setPlaybackRate(rate: number): void {
+  audioController.setPlaybackRate(rate)
+}
+
 function watchIsFinish(): void {
   watchEffect(() => {
     if (currentTime.value <= audioController._audioDuration) return
@@ -193,6 +197,7 @@ defineExpose({
   replay,
   getCurrentTime,
   getDuration,
+  setPlaybackRate,
 })
 </script>
 

--- a/src/modules/AudioController.ts
+++ b/src/modules/AudioController.ts
@@ -16,6 +16,7 @@ export default class WebAudioController extends WebAudio {
   private playing: boolean
   private audioBufferSourceNode!: AudioBufferSourceNode | null
   private FADE_DURATION: number
+  private playbackRate: number
 
   constructor(props: IllestWaveformProps) {
     super(props)
@@ -24,6 +25,7 @@ export default class WebAudioController extends WebAudio {
     this.pickAt = 0
     this.playing = false
     this.FADE_DURATION = this.props.fade ? 0.08 : 0
+    this.playbackRate = 1
   }
 
   get _playing(): boolean {
@@ -89,6 +91,14 @@ export default class WebAudioController extends WebAudio {
     this.initializeState()
   }
 
+  public setPlaybackRate(rate: number): void {
+    this.playbackRate = rate
+
+    if (this.audioBufferSourceNode) {
+      this.audioBufferSourceNode.playbackRate.value = rate
+    }
+  }
+
   private initializeState() {
     this.playing = false
     this.startAt = 0
@@ -100,6 +110,7 @@ export default class WebAudioController extends WebAudio {
     if (this.audioBufferSourceNode) return
     this.audioBufferSourceNode = this.audioCtx.createBufferSource()
     this.audioBufferSourceNode.buffer = this.audioBuffer
+    this.audioBufferSourceNode.playbackRate.value = this.playbackRate
   }
 
   private connectDestination(): void {


### PR DESCRIPTION
## Summary
- track playbackRate in the WebAudioController and apply it to created buffer sources
- expose a setPlaybackRate helper on IllestWaveform for external control
- update the public type definitions to document the new API

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d678c86a6883268ecb8a7cc5d7c428